### PR TITLE
chore: fix tree sitter version <0.22 to build for m1 and python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "tree-sitter>=0.20.0,<1.0.0", "requests>=2.0.0,<3.0.0"]
+requires = ["setuptools>=61.0.0", "wheel", "tree-sitter>=0.20.0,<0.22.0", "requests>=2.0.0,<3.0.0"]
 build-backend = "setuptools.build_meta"
 
 
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "tree-sitter >=0.20.0,<1.0.0",
+    "tree-sitter >=0.20.0,<0.22.0",
     "setuptools >=61.0.0",  # distutils removed in 3.12, but distutils.ccompiler used in tree-sitter
 ]
 


### PR DESCRIPTION
Py-Tree-Sitter in [0.22.0](https://github.com/tree-sitter/py-tree-sitter/releases/tag/v0.22.0) introduced a breaking change - now languages are installed with `pip install tree-sitter-python` etc.

This is hotfix version with tree-sitter<0.22 to build it for m1 and 3.8 python, as 0.22 not supports it.


Related #46 
Related #45 